### PR TITLE
Storing keys in reg vs file to decrease likelihood of history deletion

### DIFF
--- a/bitlocker.ps1
+++ b/bitlocker.ps1
@@ -459,141 +459,783 @@ function Set-EnforceBestPracticeEncryption {
     return $output -join "`n"
 }
 
+#region Configuration
+
+# Registry root path - NEVER change this once in production
+$script:RegistryRootPath = "HKLM:\SOFTWARE\BitLockerHistory"
+
+#region Helper Functions for Enum Conversion
+
+function Convert-VolumeStatusToString {
+    <#
+    .SYNOPSIS
+        Converts BitLocker VolumeStatus to string
+    #>
+    param($Value)
+    
+    # If already a string, return as-is
+    if ($Value -is [string]) { return $Value }
+    
+    # Convert numeric code to string
+    switch ([int]$Value) {
+        0 { return 'FullyDecrypted' }
+        1 { return 'FullyEncrypted' }
+        2 { return 'EncryptionInProgress' }
+        3 { return 'DecryptionInProgress' }
+        4 { return 'EncryptionPaused' }
+        5 { return 'DecryptionPaused' }
+        default { return "Unknown($Value)" }
+    }
+}
+
+function Convert-EncryptionMethodToString {
+    <#
+    .SYNOPSIS
+        Converts BitLocker EncryptionMethod to string
+    #>
+    param($Value)
+    
+    # If already a string, return as-is
+    if ($Value -is [string]) { return $Value }
+    
+    # Convert numeric code to string
+    switch ([int]$Value) {
+        0 { return 'None' }
+        1 { return 'Aes128' }
+        2 { return 'Aes256' }
+        3 { return 'Aes128Diffuser' }
+        4 { return 'Aes256Diffuser' }
+        6 { return 'XtsAes128' }
+        7 { return 'XtsAes256' }
+        default { return "Unknown($Value)" }
+    }
+}
+
+function Convert-ProtectionStatusToString {
+    <#
+    .SYNOPSIS
+        Converts BitLocker ProtectionStatus to string
+    #>
+    param($Value)
+    
+    # If already a string, return as-is
+    if ($Value -is [string]) { return $Value }
+    
+    # Convert numeric code to string
+    switch ([int]$Value) {
+        0 { return 'Off' }
+        1 { return 'On' }
+        2 { return 'Unknown' }
+        default { return "Unknown($Value)" }
+    }
+}
+
+function Convert-LockStatusToString {
+    <#
+    .SYNOPSIS
+        Converts BitLocker LockStatus to string
+    #>
+    param($Value)
+    
+    # If already a string, return as-is
+    if ($Value -is [string]) { return $Value }
+    
+    # Convert numeric code to string
+    switch ([int]$Value) {
+        0 { return 'Unlocked' }
+        1 { return 'Locked' }
+        default { return "Unknown($Value)" }
+    }
+}
+
+#endregion
+
+<# region Core Save Function
+.SYNOPSIS
+    BitLocker recovery key storage using Windows Registry
+
+.DESCRIPTION
+    CRITICAL PRODUCTION SYSTEM - Handles BitLocker recovery key storage with zero data loss.
+    
+    KEY PRINCIPLES:
+    1. Registry is the single source of truth
+    2. Volume IDs (not drive letters) are the primary key
+    3. ALL historical keys are preserved forever
+    4. Disconnected drives remain in registry
+    5. Keys are NEVER overwritten, only appended
+    
+    STORAGE STRUCTURE:
+    HKLM:\SOFTWARE\BitLockerHistory\
+      └─ {VolumeID}\
+          └─ Data = JSON array of all keys for this volume
+    
+    PREREQUISITES:
+    - Requires Get-BitlockerData function to be loaded first
+    
+.NOTES
+    Author: Production System
+    Date: 2025-01-17
+    Version: 1.0 (Registry-Only)
+#>
+
+# Registry root path - NEVER change this once in production
+$script:RegistryRootPath = "HKLM:\SOFTWARE\BitLockerHistory"
+
 function Save-BitlockerDataToDisk {
-    param (
-        [string]$Path = "$env:ProgramData\Bitlocker\BitLockerHistory.json"
-    )
-
-    # Load current BitLocker data
-    $currentData = Get-BitlockerData
-
-    # Load existing data from disk
-    if (Test-Path $Path) {
-        try {
-            $raw = Get-Content $Path -Raw | ConvertFrom-Json
-            $existingData = @{}
-            foreach ($volID in $raw.PSObject.Properties.Name) {
-                $existingData[$volID] = $raw.$volID
-            }
-        } catch {
-            Write-Warning "Could not read existing JSON. Starting fresh."
-            $existingData = @{}
-        }
-    } else {
-        $existingData = @{}
+    <#
+    .SYNOPSIS
+        Saves BitLocker recovery keys to Windows Registry
         
-    }
-
-    # Merge new data
-    foreach ($vol in $currentData) {
-        $volID = $vol.VolumeID
-        if (-not $existingData.ContainsKey($volID)) {
-            $existingData[$volID] = @()
+    .DESCRIPTION
+        This is the PRIMARY function that ensures zero data loss.
+        
+        CRITICAL WORKFLOW:
+        1. Get current volumes from system (may be subset if drives removed)
+        2. Load ALL existing data from registry (includes disconnected drives)
+        3. Merge current + existing (preserves all historical data)
+        4. Save merged data back to registry
+        
+        This ensures that even if D: is disconnected, its keys remain in registry.
+        
+    .EXAMPLE
+        Save-BitlockerDataToDisk
+        Saves all current BitLocker volumes and preserves historical data
+        
+    .EXAMPLE
+        Save-BitlockerDataToDisk -Verbose
+        Shows detailed logging of what's being saved
+    #>
+    [CmdletBinding()]
+    param()
+    
+    try {
+        Write-Verbose "=== Starting BitLocker Key Save Operation ==="
+        
+        # STEP 1: Get current BitLocker volumes from the system
+        # NOTE: This only includes CONNECTED drives
+        Write-Verbose "STEP 1: Getting current BitLocker volumes from system..."
+        $currentVolumes = Get-BitlockerData
+        
+        if (!$currentVolumes -or $currentVolumes.Count -eq 0) {
+            Write-Warning "No BitLocker volumes found on system. Nothing to save."
+            return
         }
+        
+        Write-Verbose "Found $($currentVolumes.Count) current volume(s) on system"
+        foreach ($vol in $currentVolumes) {
+            Write-Verbose "  - Volume ID: $($vol.VolumeID), Mount: $($vol.MountPoint), Type: $($vol.DriveType)"
+        }
+        
+        # STEP 2: Load ALL existing data from registry (includes disconnected drives)
+        Write-Verbose "`nSTEP 2: Loading ALL existing data from registry..."
+        $existingData = Get-AllExistingRegistryData
+        
+        if ($existingData.Count -gt 0) {
+            Write-Verbose "Found $($existingData.Count) volume(s) in registry (includes disconnected drives)"
+            foreach ($volID in $existingData.Keys) {
+                $keyCount = $existingData[$volID].Count
+                Write-Verbose "  - Volume ID: $volID has $keyCount historical entry(ies)"
+            }
+        } else {
+            Write-Verbose "No existing data in registry (first run)"
+        }
+        
+        # STEP 3: Merge current system data with existing registry data
+        Write-Verbose "`nSTEP 3: Merging current volumes with existing registry data..."
+        $mergedData = Merge-VolumeData -CurrentVolumes $currentVolumes -ExistingData $existingData
+        
+        Write-Verbose "After merge: $($mergedData.Count) total volume(s) to save"
+        
+        # STEP 4: Save merged data to registry
+        Write-Verbose "`nSTEP 4: Saving merged data to registry..."
+        Save-MergedDataToRegistry -MergedData $mergedData
+        
+        Write-Verbose "`n=== BitLocker Key Save Operation Complete ==="
+        Write-Verbose "All data safely saved to registry"
+        
+    } catch {
+        Write-Error "CRITICAL ERROR in Save-BitlockerDataToDisk: $($_.Exception.Message)"
+        Write-Error "Stack Trace: $($_.ScriptStackTrace)"
+        throw
+    }
+}
 
-        $existingKeys = $existingData[$volID] | ForEach-Object {
-            if ($_.RecoveryPassword -is [array]) { $_.RecoveryPassword } else { @($_.RecoveryPassword) }
-        } | Select-Object -Unique
+#endregion
 
-        $newKeys = if ($vol.RecoveryPassword -is [array]) { $vol.RecoveryPassword } else { @($vol.RecoveryPassword) }
+#region Internal Functions
 
-        foreach ($key in $newKeys) {
-            if ($key -and $key -ne 'None' -and ($existingKeys -notcontains $key)) {
-                $entry = [PSCustomObject]@{
-                    Date              = (Get-Date).ToString('s')
-                    MountPoint        = $vol.MountPoint
-                    RecoveryPassword  = @($key)
-                    VolumeType        = $vol.VolumeType
-                    EncryptionMethod  = $vol.EncryptionMethod
-                    VolumeStatus      = $vol.VolumeStatus
-                    ProtectionStatus  = $vol.ProtectionStatus
-                    LockStatus        = $vol.LockStatus
-                    EncryptionPercent = $vol.EncryptionPercentage
+function Get-AllExistingRegistryData {
+    <#
+    .SYNOPSIS
+        Loads ALL volume data from registry
+        
+    .DESCRIPTION
+        Returns a hashtable where:
+        - Key = VolumeID
+        - Value = Array of historical entries for that volume
+        
+        This includes data for disconnected drives.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+    
+    $allData = @{}
+    
+    # Check if registry path exists
+    if (!(Test-Path $script:RegistryRootPath)) {
+        Write-Verbose "Registry path does not exist yet (first run)"
+        return $allData
+    }
+    
+    # Get all volume subkeys
+    try {
+        $volumeKeys = Get-ChildItem -Path $script:RegistryRootPath -ErrorAction Stop
+        
+        foreach ($volKey in $volumeKeys) {
+            $volumeID = $volKey.PSChildName
+            
+            try {
+                # Read the Data property for this volume
+                $jsonData = Get-ItemProperty -Path $volKey.PSPath -Name "Data" -ErrorAction Stop | 
+                    Select-Object -ExpandProperty Data
+                
+                # Parse JSON to array of entries
+                $entries = $jsonData | ConvertFrom-Json
+                
+                # Ensure it's an array (even if single entry)
+                if ($entries -isnot [array]) {
+                    $entries = @($entries)
                 }
-                $existingData[$volID] += $entry
+                
+                $allData[$volumeID] = $entries
+                
+                Write-Verbose "Loaded $($entries.Count) entry(ies) for volume $volumeID"
+                
+            } catch {
+                Write-Warning "Could not read data for volume $volumeID : $($_.Exception.Message)"
+                # Continue with other volumes
             }
         }
+        
+    } catch {
+        Write-Warning "Could not enumerate registry volumes: $($_.Exception.Message)"
     }
+    
+    return $allData
+}
 
-    # Convert the final data to JSON once
-    $jsonOut = [pscustomobject]$existingData | ConvertTo-Json -Depth 5
+function Merge-VolumeData {
+    <#
+    .SYNOPSIS
+        Merges current system volumes with existing registry data
+        
+    .DESCRIPTION
+        CRITICAL MERGE LOGIC:
+        - Start with ALL existing registry data (includes disconnected drives)
+        - For each current volume, add ONLY NEW keys
+        - Never overwrite or remove existing keys
+        - Preserve all historical data
+        
+    .PARAMETER CurrentVolumes
+        Array of volume objects from Get-BitlockerData (current system state)
+        
+    .PARAMETER ExistingData
+        Hashtable of existing registry data (includes historical/disconnected volumes)
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        $CurrentVolumes,
+        
+        [Parameter(Mandatory = $true)]
+        [hashtable]$ExistingData
+    )
+    
+    # Start with a COPY of existing data (includes disconnected drives)
+    $merged = @{}
+    foreach ($volID in $ExistingData.Keys) {
+        $merged[$volID] = $ExistingData[$volID]
+    }
+    
+    Write-Verbose "Starting merge with $($merged.Count) existing volume(s) from registry"
+    
+    # Process each current volume
+    foreach ($vol in $CurrentVolumes) {
+        $volumeID = $vol.VolumeID
+        
+        if (!$volumeID) {
+            Write-Warning "Volume at $($vol.MountPoint) has no VolumeID - skipping"
+            continue
+        }
+        
+        # Initialize array for this volume if it doesn't exist
+        if (!$merged.ContainsKey($volumeID)) {
+            $merged[$volumeID] = @()
+            Write-Verbose "New volume detected: $volumeID"
+        }
+        
+        # Get all existing recovery keys for this volume
+        $existingKeys = $merged[$volumeID] | ForEach-Object {
+            if ($_.RecoveryPassword -is [array]) {
+                $_.RecoveryPassword
+            } else {
+                @($_.RecoveryPassword)
+            }
+        } | Where-Object { $_ -and $_ -ne 'None' } | Select-Object -Unique
+        
+        # Get current keys for this volume
+        $currentKeys = if ($vol.RecoveryPassword -is [array]) {
+            $vol.RecoveryPassword
+        } else {
+            @($vol.RecoveryPassword)
+        }
+        
+        # Add ONLY new keys that don't already exist
+        $newKeysAdded = 0
+        foreach ($key in $currentKeys) {
+            # Skip invalid keys
+            if (!$key -or $key -eq 'None') {
+                continue
+            }
+            
+            # Check if this key already exists
+            if ($existingKeys -contains $key) {
+                Write-Verbose "Volume $volumeID : Key already exists (skipping)"
+                continue
+            }
+            
+            # Create new entry for this key
+            # CRITICAL: Force convert enum values to strings to prevent JSON serialization as integers
+            $newEntry = [PSCustomObject]@{
+                Date              = (Get-Date).ToString('o')  # ISO 8601 format
+                MountPoint        = $vol.MountPoint
+                RecoveryPassword  = $key
+                VolumeType        = $vol.VolumeType
+                EncryptionMethod  = [string]$vol.EncryptionMethod
+                VolumeStatus      = [string]$vol.VolumeStatus
+                ProtectionStatus  = [string]$vol.ProtectionStatus
+                LockStatus        = [string]$vol.LockStatus
+                EncryptionPercent = $vol.EncryptionPercentage
+                DriveType         = $vol.DriveType
+            }
+            
+            # Add to merged data
+            $merged[$volumeID] += $newEntry
+            $newKeysAdded++
+            
+            Write-Verbose "Volume $volumeID : Added NEW key ending in ...$(($key -split '-')[-1])"
+        }
+        
+        if ($newKeysAdded -eq 0) {
+            Write-Verbose "Volume $volumeID : No new keys to add (all keys already recorded)"
+        }
+    }
+    
+    Write-Verbose "Merge complete: $($merged.Count) total volume(s) in final dataset"
+    
+    return $merged
+}
 
-    # Write revision copy
-    $timestamp = Get-Date -Format "yyyy-MM-dd_HHmmss"
-    $folderPath = Split-Path -Path $Path -Parent
-    $revPath = Join-Path $folderPath "BitLockerHistory_$timestamp.json"
-    $jsonOut | Set-Content -Path $revPath -Encoding UTF8
+function Save-MergedDataToRegistry {
+    <#
+    .SYNOPSIS
+        Saves merged data to registry
+        
+    .DESCRIPTION
+        Writes each volume's data to its own registry key.
+        Uses JSON serialization for the data array.
+        
+    .PARAMETER MergedData
+        Hashtable where Key=VolumeID, Value=Array of entries
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$MergedData
+    )
+    
+    # Ensure root registry path exists
+    if (!(Test-Path $script:RegistryRootPath)) {
+        Write-Verbose "Creating registry root path: $script:RegistryRootPath"
+        New-Item -Path $script:RegistryRootPath -Force | Out-Null
+    }
+    
+    # Save each volume
+    foreach ($volumeID in $MergedData.Keys) {
+        # Get entries for this volume
+        $entries = $MergedData[$volumeID]
+        
+        # Skip volumes with no entries (don't create empty registry keys)
+        if (!$entries -or $entries.Count -eq 0) {
+            Write-Verbose "Volume $volumeID has no entries - skipping registry creation"
+            continue
+        }
+        
+        $volumePath = Join-Path $script:RegistryRootPath $volumeID
+        
+        # Ensure volume key exists
+        if (!(Test-Path $volumePath)) {
+            Write-Verbose "Creating registry key for volume: $volumeID"
+            New-Item -Path $volumePath -Force | Out-Null
+        }
+        
+        # Serialize to JSON
+        # Note: -Compress keeps registry size manageable
+        $jsonData = $entries | ConvertTo-Json -Depth 10 -Compress
+        
+        # Save to registry
+        try {
+            Set-ItemProperty -Path $volumePath -Name "Data" -Value $jsonData -Type String -Force -ErrorAction Stop
+            Write-Verbose "Saved $($entries.Count) entry(ies) for volume $volumeID"
+        } catch {
+            Write-Error "Failed to save volume $volumeID to registry: $($_.Exception.Message)"
+            throw
+        }
+    }
+    
+    Write-Verbose "All volumes saved to registry successfully"
+}
 
-    # Write to main file
-    $jsonOut | Set-Content -Path $Path -Encoding UTF8
+#endregion
+
+#region Read Functions
+
+function Get-BitlockerDataSavedToDiskSummary {
+    <#
+    .SYNOPSIS
+        Gets the most recent recovery key for each volume
+        
+    .DESCRIPTION
+        Returns a summary showing the newest key for each volume.
+        This is what Ninja should call to collect current keys.
+        
+        IMPORTANT: This shows ALL volumes in registry, including disconnected drives.
+        
+    .OUTPUTS
+        Array of strings with formatted key information
+        
+    .EXAMPLE
+        Get-BitlockerDataSavedToDiskSummary
+        Returns summary of all volumes and their most recent keys
+        
+    .EXAMPLE
+        Get-BitlockerDataSavedToDiskSummary | Out-File C:\keys.txt
+        Exports key summary to file
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+    
+    try {
+        # Load all data from registry
+        $allData = Get-AllExistingRegistryData
+        
+        if ($allData.Count -eq 0) {
+            Write-Warning "No BitLocker data found in registry"
+            return @()
+        }
+        
+        $summary = @()
+        
+        foreach ($volumeID in $allData.Keys) {
+            $entries = $allData[$volumeID]
+            
+            if (!$entries -or $entries.Count -eq 0) {
+                continue
+            }
+            
+            # Sort by date and get most recent entry
+            $sortedEntries = $entries | Sort-Object { [datetime]$_.Date } -Descending
+            $mostRecent = $sortedEntries[0]
+            
+            # Format output
+            $output = "VolumeID: $volumeID | " +
+                      "Date: $($mostRecent.Date) | " +
+                      "Mount: $($mostRecent.MountPoint) | " +
+                      "Type: $($mostRecent.DriveType) | " +
+                      "Status: $($mostRecent.VolumeStatus) | " +
+                      "Encrypted: $($mostRecent.EncryptionPercent)% | " +
+                      "Method: $($mostRecent.EncryptionMethod) | " +
+                      "Protection: $($mostRecent.ProtectionStatus) | " +
+                      "Key: $($mostRecent.RecoveryPassword)"
+            
+            $summary += $output
+        }
+        
+        return $summary
+        
+    } catch {
+        Write-Error "Error getting BitLocker key summary: $($_.Exception.Message)"
+        throw
+    }
 }
 
 function Get-BitlockerDataSavedToDisk {
-    $filePath = "$env:ProgramData\Bitlocker\BitLockerHistory.json"
-    if (-not (Test-Path $filePath)) {
-        Write-Warning "BitLocker history file not found."
-        return @()
-    }
-
-    $raw = Get-Content $filePath -Raw | ConvertFrom-Json
-    $result = @()
-
-    foreach ($volumeID in $raw.PSObject.Properties.Name) {
-        $entries = $raw.$volumeID
-        if ($entries -and $entries.Count -gt 0) {
-            foreach ($entry in $entries) {
-                $entry | Add-Member -NotePropertyName VolumeID -NotePropertyValue $volumeID -Force
-                $result += $entry
-            }
+    <#
+    .SYNOPSIS
+        Gets complete history for a specific volume
+        
+    .DESCRIPTION
+        Shows ALL historical keys for a given volume ID.
+        Useful for troubleshooting or auditing.
+        
+    .PARAMETER VolumeID
+        The volume ID to query (GUID without braces)
+        
+    .EXAMPLE
+        Get-BitlockerDataSavedToDisk -VolumeID "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        Shows all historical keys for this volume
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$VolumeID
+    )
+    
+    try {
+        $volumePath = Join-Path $script:RegistryRootPath $VolumeID
+        
+        if (!(Test-Path $volumePath)) {
+            Write-Warning "Volume $VolumeID not found in registry"
+            return @()
         }
+        
+        $jsonData = Get-ItemProperty -Path $volumePath -Name "Data" -ErrorAction Stop | 
+            Select-Object -ExpandProperty Data
+        
+        $entries = $jsonData | ConvertFrom-Json
+        
+        if ($entries -isnot [array]) {
+            $entries = @($entries)
+        }
+        
+        # Sort by date descending (newest first)
+        $sorted = $entries | Sort-Object { [datetime]$_.Date } -Descending
+        
+        return $sorted
+        
+    } catch {
+        Write-Error "Error getting history for volume $VolumeID : $($_.Exception.Message)"
+        throw
     }
-
-    return $result
 }
 
-function Get-BitlockerDataSavedToDiskSummary {
-    $jsonPath = "$env:ProgramData\Bitlocker\BitLockerHistory.json"
+function Get-AllBitlockerKeyData {
+    <#
+    .SYNOPSIS
+        Gets ALL BitLocker key data from registry
+        
+    .DESCRIPTION
+        Returns complete dataset including all volumes and all historical entries.
+        
+    .OUTPUTS
+        Hashtable where Key=VolumeID, Value=Array of entries
+        
+    .EXAMPLE
+        $allData = Get-AllBitlockerKeyData
+        $allData.Keys  # Shows all volume IDs
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+    
+    return Get-AllExistingRegistryData
+}
 
-    if (!(Test-Path $jsonPath)) {
-        Write-Warning "No BitLocker history file found at $jsonPath"
+#endregion
+
+#region Utility Functions
+
+function Clear-BitlockerRegistry {
+    <#
+    .SYNOPSIS
+        Clears all BitLocker data from registry
+        
+    .DESCRIPTION
+        USE WITH CAUTION: Deletes all stored BitLocker keys from registry.
+        You should immediately run Save-BitlockerDataToDisk after this.
+        
+    .PARAMETER Force
+        Required to confirm deletion
+        
+    .EXAMPLE
+        Clear-BitlockerRegistry -Force
+        Save-BitlockerDataToDisk
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [switch]$Force
+    )
+    
+    if (Test-Path $script:RegistryRootPath) {
+        Write-Warning "Deleting all BitLocker data from registry..."
+        Remove-Item -Path $script:RegistryRootPath -Recurse -Force
+        Write-Host "✓ Registry cleared" -ForegroundColor Green
+        Write-Host "Run Save-BitlockerDataToDisk to re-save current data" -ForegroundColor Yellow
+    } else {
+        Write-Host "Registry path does not exist (already clean)" -ForegroundColor Green
+    }
+}
+
+function Test-BitlockerRegistryIntegrity {
+    <#
+    .SYNOPSIS
+        Validates registry data integrity
+        
+    .DESCRIPTION
+        Checks that all registry data is valid and readable.
+        Reports any issues found.
+    #>
+    [CmdletBinding()]
+    param()
+    
+    Write-Host "`n=== BitLocker Registry Integrity Check ===" -ForegroundColor Cyan
+    
+    if (!(Test-Path $script:RegistryRootPath)) {
+        Write-Host "Registry path does not exist: $script:RegistryRootPath" -ForegroundColor Yellow
+        Write-Host "This is normal if no keys have been saved yet." -ForegroundColor Yellow
         return
     }
-
-    $jsonData = Get-Content $jsonPath -Raw | ConvertFrom-Json
-
-    foreach ($volumeID in $jsonData.PSObject.Properties.Name) {
-        $history = $jsonData.$volumeID
-        if ($history.Count -eq 0) { continue }
-
-        $flattened = foreach ($entry in $history) {
-            $keys = if ($entry.RecoveryPassword -is [array]) {
-                $entry.RecoveryPassword
-            } else {
-                @($entry.RecoveryPassword)
+    
+    $allData = Get-AllExistingRegistryData
+    $volumeCount = $allData.Keys.Count
+    $totalEntries = 0
+    $issues = 0
+    
+    Write-Host "`nRegistry Path: $script:RegistryRootPath" -ForegroundColor Gray
+    Write-Host "Total Volumes: $volumeCount" -ForegroundColor Green
+    
+    foreach ($volumeID in $allData.Keys) {
+        $entries = $allData[$volumeID]
+        $entryCount = $entries.Count
+        $totalEntries += $entryCount
+        
+        Write-Host "`nVolume: $volumeID" -ForegroundColor Cyan
+        Write-Host "  Entries: $entryCount" -ForegroundColor Gray
+        
+        # Validate each entry
+        foreach ($entry in $entries) {
+            $hasIssue = $false
+            
+            if (!$entry.Date) {
+                Write-Host "    ⚠ Missing Date" -ForegroundColor Yellow
+                $hasIssue = $true
             }
-
-            foreach ($k in $keys) {
-                if ($k -and $k -ne 'None' -and $k -ne '') {
-                    [PSCustomObject]@{
-                        RecoveryPassword = $k
-                        Date             = [datetime]$entry.Date
-                        MountPoint       = $entry.MountPoint
-                    }
-                }
+            
+            if (!$entry.RecoveryPassword -or $entry.RecoveryPassword -eq 'None') {
+                Write-Host "    ⚠ Missing Recovery Password" -ForegroundColor Yellow
+                $hasIssue = $true
+            }
+            
+            if (!$entry.MountPoint) {
+                Write-Host "    ⚠ Missing MountPoint" -ForegroundColor Yellow
+                $hasIssue = $true
+            }
+            
+            if ($hasIssue) {
+                $issues++
             }
         }
-
-        if (-not $flattened) { continue }
-
-        # Group by key, select most recent date per key
-        $latestKeyEntry = $flattened |
-            Group-Object RecoveryPassword |
-            ForEach-Object {
-                $_.Group | Sort-Object Date -Descending | Select-Object -First 1
-            } |
-            Sort-Object Date -Descending |
-            Select-Object -First 1
-
-        "Date: $($latestKeyEntry.Date.ToString('s')), ID: $volumeID, Letter: $($latestKeyEntry.MountPoint), RecoveryPassword: $($latestKeyEntry.RecoveryPassword)"
+        
+        if ($issues -eq 0) {
+            Write-Host "  ✓ All entries valid" -ForegroundColor Green
+        }
+    }
+    
+    Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+    Write-Host "Total Entries: $totalEntries" -ForegroundColor Green
+    Write-Host "Issues Found: $issues" -ForegroundColor $(if($issues -eq 0){'Green'}else{'Yellow'})
+    
+    if ($issues -eq 0) {
+        Write-Host "`n✓ Registry data is healthy" -ForegroundColor Green
     }
 }
+
+function Export-BitlockerKeysToFile {
+    <#
+    .SYNOPSIS
+        Exports all BitLocker keys to a JSON file
+        
+    .DESCRIPTION
+        Creates a human-readable backup of all registry data.
+        Useful for disaster recovery or migration.
+        
+    .PARAMETER Path
+        Output file path (default: Desktop)
+        
+    .EXAMPLE
+        Export-BitlockerKeysToFile
+        Exports to Desktop with timestamp
+        
+    .EXAMPLE
+        Export-BitlockerKeysToFile -Path "C:\Backup\keys.json"
+        Exports to specific file
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Path = "$env:USERPROFILE\Desktop\BitLockerKeys_$(Get-Date -Format 'yyyyMMdd_HHmmss').json"
+    )
+    
+    try {
+        $allData = Get-AllExistingRegistryData
+        
+        if ($allData.Count -eq 0) {
+            Write-Warning "No data to export"
+            return
+        }
+        
+        # Convert to JSON with nice formatting
+        $json = $allData | ConvertTo-Json -Depth 10
+        
+        # Save to file
+        $json | Set-Content -Path $Path -Encoding UTF8
+        
+        Write-Host "✓ Exported to: $Path" -ForegroundColor Green
+        Write-Host "  Volumes: $($allData.Keys.Count)" -ForegroundColor Gray
+        
+        return $Path
+        
+    } catch {
+        Write-Error "Failed to export: $($_.Exception.Message)"
+        throw
+    }
+}
+
+#endregion
+
+#region For NinjaRMM Integration
+
+function Get-BitlockerKeysForNinja {
+    <#
+    .SYNOPSIS
+        Gets BitLocker keys in format optimized for NinjaRMM custom fields
+        
+    .DESCRIPTION
+        Returns a formatted string suitable for storing in Ninja custom fields.
+        Shows most recent key for each volume.
+        
+    .OUTPUTS
+        String - Formatted key data for Ninja
+        
+    .EXAMPLE
+        $keys = Get-BitlockerKeysForNinja
+        Ninja-Property-Set bitlockerKeys $keys
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    
+    $summary = Get-BitlockerDataSavedToDiskSummary
+    
+    if ($summary.Count -eq 0) {
+        return "No BitLocker keys found"
+    }
+    
+    return $summary -join "`n"
+}
+
+#endregion

--- a/bitlocker.ps1
+++ b/bitlocker.ps1
@@ -813,7 +813,7 @@ function Merge-VolumeData {
                 Date              = (Get-Date).ToString('o')  # ISO 8601 format
                 MountPoint        = $vol.MountPoint
                 RecoveryPassword  = $key
-                VolumeType        = $vol.VolumeType
+                VolumeType        = [string]$vol.VolumeType
                 EncryptionMethod  = [string]$vol.EncryptionMethod
                 VolumeStatus      = [string]$vol.VolumeStatus
                 ProtectionStatus  = [string]$vol.ProtectionStatus

--- a/bitlocker.ps1
+++ b/bitlocker.ps1
@@ -1206,36 +1206,3 @@ function Export-BitlockerKeysToFile {
 }
 
 #endregion
-
-#region For NinjaRMM Integration
-
-function Get-BitlockerKeysForNinja {
-    <#
-    .SYNOPSIS
-        Gets BitLocker keys in format optimized for NinjaRMM custom fields
-        
-    .DESCRIPTION
-        Returns a formatted string suitable for storing in Ninja custom fields.
-        Shows most recent key for each volume.
-        
-    .OUTPUTS
-        String - Formatted key data for Ninja
-        
-    .EXAMPLE
-        $keys = Get-BitlockerKeysForNinja
-        Ninja-Property-Set bitlockerKeys $keys
-    #>
-    [CmdletBinding()]
-    [OutputType([string])]
-    param()
-    
-    $summary = Get-BitlockerDataSavedToDiskSummary
-    
-    if ($summary.Count -eq 0) {
-        return "No BitLocker keys found"
-    }
-    
-    return $summary -join "`n"
-}
-
-#endregion

--- a/bitlocker.ps1
+++ b/bitlocker.ps1
@@ -550,9 +550,7 @@ function Convert-LockStatusToString {
 
 #endregion
 
-#endregion
-
-#region Core Save Function<#
+<# region Core Save Function
 .SYNOPSIS
     BitLocker recovery key storage using Windows Registry
 

--- a/entra.ps1
+++ b/entra.ps1
@@ -1,13 +1,14 @@
 function Get-EntraJoinStatus {
     <#
     .SYNOPSIS
-        Gets the current Entra ID (Azure AD) join status of the device.
+        Gets the current Entra ID (Azure AD) join status of the device
     
     .DESCRIPTION
         Queries dsregcmd to determine how the device is joined to Entra ID/Azure AD.
+        Works correctly when running as SYSTEM by checking registry for user-level joins.
     
     .OUTPUTS
-        String - Returns one of: "EntraJoined", "HybridJoined", "DomainJoined", "EntraRegistered", "NotJoined", or "Unknown"
+        String - Returns one of: "EntraJoined", "HybridJoined", "DomainJoined", "DomainJoined+EntraRegistered", "EntraRegistered", "NotJoined", or "Unknown"
     
     .EXAMPLE
         Get-EntraJoinStatus
@@ -19,7 +20,6 @@ function Get-EntraJoinStatus {
     param()
     
     try {
-        # Run dsregcmd and capture output
         $dsreg = dsregcmd /status
         
         if ($LASTEXITCODE -ne 0) {
@@ -27,26 +27,30 @@ function Get-EntraJoinStatus {
             return "Unknown"
         }
         
-        # Parse relevant fields from dsregcmd output
         $azureADJoined = ($dsreg | Select-String "AzureAdJoined\s*:\s*(.*)").Matches.Groups[1].Value.Trim()
         $domainJoined = ($dsreg | Select-String "DomainJoined\s*:\s*(.*)").Matches.Groups[1].Value.Trim()
         $workplaceJoined = ($dsreg | Select-String "WorkplaceJoined\s*:\s*(.*)").Matches.Groups[1].Value.Trim()
         
-        # Determine and return join status
-        if ($azureADJoined -eq "YES" -and $domainJoined -eq "YES") {
-            return "HybridJoined"
+        $isAzureAD = $azureADJoined -eq "YES"
+        $isDomain = $domainJoined -eq "YES"
+        $isWorkplace = $workplaceJoined -eq "YES"
+        
+        if (!$isWorkplace -and $isDomain) {
+            $isWorkplace = Test-AnyUserWorkplaceJoined
         }
-        elseif ($azureADJoined -eq "YES" -and $domainJoined -eq "NO") {
-            return "EntraJoined"
-        }
-        elseif ($domainJoined -eq "YES" -and $azureADJoined -eq "NO") {
-            return "DomainJoined"
-        }
-        elseif ($workplaceJoined -eq "YES") {
-            return "EntraRegistered"
-        }
-        else {
-            return "NotJoined"
+        
+        $statusKey = "$isAzureAD|$isDomain|$isWorkplace"
+        
+        switch ($statusKey) {
+            "True|True|True"  { return "HybridJoined" }
+            "True|True|False" { return "HybridJoined" }
+            "True|False|True"  { return "EntraJoined" }
+            "True|False|False" { return "EntraJoined" }
+            "False|True|True" { return "DomainJoined+EntraRegistered" }
+            "False|True|False" { return "DomainJoined" }
+            "False|False|True" { return "EntraRegistered" }
+            "False|False|False" { return "NotJoined" }
+            default { return "Unknown" }
         }
         
     } catch {
@@ -55,18 +59,48 @@ function Get-EntraJoinStatus {
     }
 }
 
+function Test-AnyUserWorkplaceJoined {
+    <#
+    .SYNOPSIS
+        Checks if any user on the machine has WorkplaceJoin (Entra Registered)
+        
+    .DESCRIPTION
+        When running as SYSTEM, dsregcmd only shows machine-level joins.
+        This function checks all user registry hives to detect user-level WorkplaceJoin.
+    #>
+    
+    try {
+        $userSIDs = Get-ChildItem "Registry::HKEY_USERS" -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'S-1-5-21-' -and $_.Name -notmatch '_Classes$' }
+        
+        foreach ($userHive in $userSIDs) {
+            $wpjPath = "$($userHive.PSPath)\Software\Microsoft\Windows NT\CurrentVersion\WorkplaceJoin"
+            
+            if (Test-Path $wpjPath -ErrorAction SilentlyContinue) {
+                $wpjKeys = Get-ChildItem $wpjPath -ErrorAction SilentlyContinue
+                if ($wpjKeys -and $wpjKeys.Count -gt 0) {
+                    return $true
+                }
+            }
+        }
+        
+        return $false
+        
+    } catch {
+        return $false
+    }
+}
 
 function Test-EntraCompliance {
     <#
     .SYNOPSIS
-        Tests if the device's Entra ID join status is compliant.
+        Tests if the device's Entra ID join status is compliant
     
     .DESCRIPTION
-        Checks if the current device join status matches one of the specified compliant states.
+        Checks if the current device join status matches one of the specified compliant states
     
     .PARAMETER CompliantStates
         Array of join states that are considered compliant.
-        Valid values: "EntraJoined", "HybridJoined", "DomainJoined", "EntraRegistered", "NotJoined"
+        Valid values: "EntraJoined", "HybridJoined", "DomainJoined", "DomainJoined+EntraRegistered", "EntraRegistered", "NotJoined"
     
     .OUTPUTS
         Boolean - Returns $true if compliant, $false if not compliant
@@ -84,14 +118,12 @@ function Test-EntraCompliance {
     [OutputType([Boolean])]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("EntraJoined", "HybridJoined", "DomainJoined", "EntraRegistered", "NotJoined")]
+        [ValidateSet("EntraJoined", "HybridJoined", "DomainJoined", "DomainJoined+EntraRegistered", "EntraRegistered", "NotJoined")]
         [String[]]$CompliantStates
     )
     
-    # Get current join status
     $currentStatus = Get-EntraJoinStatus
     
-    # Check if current status is in the compliant list
     if ($currentStatus -in $CompliantStates) {
         return $true
     } else {


### PR DESCRIPTION
If we store the key in files and that's what we use for our history, it's highly possible that someone deletes the key storage files from the hard drive which would lose our history... that's not very robust. To combat that, I'm storing them in reg which is very unlikely to be modified/deleted since no one will know where it's located.

Storing the keys in `HKLM:\SOFTWARE\BitLockerHistory` and making a new key for each volume ID. Tested on multiple VMs / laptops / desktops and have proven it to be robust and effective even with external drives removed and keys changed.